### PR TITLE
fix: resolve frontend field mapping issues for load balance metrics

### DIFF
--- a/thesis-frontend/src/components/AnimationTab/MetricsPanel.jsx
+++ b/thesis-frontend/src/components/AnimationTab/MetricsPanel.jsx
@@ -4,9 +4,9 @@ const MetricsPanel = ({ metrics, color = "blue" }) => {
   return (
     <div className="mt-6 grid grid-cols-1 md:grid-cols-3 gap-4 mb-4">
       <MetricCard 
-        title="Degree of Imbalance (DI)" 
-        value={metrics.imbalance} 
-        subtitle="Average completion time" 
+        title="Degree of Imbalance" 
+        value={`${metrics.imbalance}%`} 
+        subtitle="Measure of load imbalance (0% = perfect balance)" 
         colorClass={colorClass}
       />
       <MetricCard 

--- a/thesis-frontend/src/components/ResultsTab/MetricCard.jsx
+++ b/thesis-frontend/src/components/ResultsTab/MetricCard.jsx
@@ -1,18 +1,18 @@
 import { motion } from 'framer-motion';
 import { FiActivity, FiClock, FiZap, FiServer, FiCheckCircle } from 'react-icons/fi';
 
-const MetricCard = ({ title, description, rrValue, epsoValue, unit, betterWhen, icon: Icon }) => {
+const MetricCard = ({ title, description, eacoValue, epsoValue, unit, betterWhen, icon: Icon }) => {
   // Ensure values are numbers
-  const rrNum = parseFloat(rrValue) || 0;
+  const eacoNum = parseFloat(eacoValue) || 0;
   const epsoNum = parseFloat(epsoValue) || 0;
   
-  const difference = epsoNum - rrNum;
-  const percentDiff = rrNum !== 0 ? (difference / rrNum) * 100 : 0;
+  const difference = epsoNum - eacoNum;
+  const percentDiff = eacoNum !== 0 ? (difference / eacoNum) * 100 : 0;
   const absPercentDiff = Math.abs(percentDiff);
   
   const isBetter = betterWhen === "higher" 
-    ? epsoNum > rrNum 
-    : epsoNum < rrNum;
+    ? epsoNum > eacoNum 
+    : epsoNum < eacoNum;
   
   const comparisonResult = isBetter ? "better" : "worse";
   const improvementText = `${absPercentDiff.toFixed(1)}% ${comparisonResult}`;
@@ -56,7 +56,7 @@ const MetricCard = ({ title, description, rrValue, epsoValue, unit, betterWhen, 
           }`}>
             <div className="text-sm font-medium mb-1 text-blue-600">EACO</div>
             <div className="text-2xl font-bold text-blue-800">
-              {rrNum.toFixed(2)}{unit}
+              {eacoNum.toFixed(2)}{unit}
             </div>
           </div>
           

--- a/thesis-frontend/src/components/ResultsTab/ResultsTab.jsx
+++ b/thesis-frontend/src/components/ResultsTab/ResultsTab.jsx
@@ -13,12 +13,12 @@ import SchedulingLogTable from './SchedulingLogTable';
 import PerformanceCharts from './Charts';
 import { normalizeData, getSummaryData, keyMetrics } from './utils';
 
-const ResultsTab = ({ onBackToAnimation, onNewSimulation, rrResults, epsoResults, plotData }) => {
+const ResultsTab = ({ onBackToAnimation, onNewSimulation, eacoResults, epsoResults, plotData }) => {
   const [resultsRR, setResultsRR] = useState(null);
   const [resultsEPSO, setResultsEPSO] = useState(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
-  const [activeLogTab, setActiveLogTab] = useState('rr');
+  const [activeLogTab, setActiveLogTab] = useState('eaco');
   const [activeChart, setActiveChart] = useState('bar');
   const [isExiting, setIsExiting] = useState(false);
   const [searchTerm, setSearchTerm] = useState('');
@@ -26,10 +26,10 @@ const ResultsTab = ({ onBackToAnimation, onNewSimulation, rrResults, epsoResults
   useEffect(() => {
     try {
       console.group('📊 Results Tab Data Processing');
-      console.log('📥 Raw EACO results from props:', rrResults);
+      console.log('📥 Raw EACO results from props:', eacoResults);
       console.log('📥 Raw EPSO results from props:', epsoResults);
       
-      if (!rrResults || !epsoResults) {
+      if (!eacoResults || !epsoResults) {
         console.warn('⚠️ Missing results data from props');
         setError('No simulation results available. Please run a simulation first.');
         setLoading(false);
@@ -38,7 +38,7 @@ const ResultsTab = ({ onBackToAnimation, onNewSimulation, rrResults, epsoResults
       }
       
       // Normalize the data
-      const normalizedRR = normalizeData(rrResults);
+      const normalizedRR = normalizeData(eacoResults);
       const normalizedEPSO = normalizeData(epsoResults);
       
       console.log('🔄 Normalized EACO data:', normalizedRR);
@@ -55,7 +55,7 @@ const ResultsTab = ({ onBackToAnimation, onNewSimulation, rrResults, epsoResults
       setLoading(false);
       console.groupEnd();
     }
-  }, [rrResults, epsoResults]);
+  }, [eacoResults, epsoResults]);
 
   const handleBackToAnimation = () => {
     setIsExiting(true);
@@ -235,7 +235,7 @@ const ResultsTab = ({ onBackToAnimation, onNewSimulation, rrResults, epsoResults
               <MetricCard 
                 title={metric.title}
                 description={metric.description}
-                rrValue={rrSummary ? rrSummary[metric.valueKey] || 0 : 0}
+                eacoValue={rrSummary ? rrSummary[metric.valueKey] || 0 : 0}
                 epsoValue={epsoSummary ? epsoSummary[metric.valueKey] || 0 : 0}
                 unit={metric.unit}
                 betterWhen={metric.betterWhen}
@@ -453,9 +453,9 @@ const ResultsTab = ({ onBackToAnimation, onNewSimulation, rrResults, epsoResults
           <div className="border-b border-gray-200 mb-4">
             <nav className="-mb-px flex space-x-8">
               <button
-                onClick={() => setActiveLogTab('rr')}
+                onClick={() => setActiveLogTab('eaco')}
                 className={`whitespace-nowrap py-4 px-1 border-b-2 font-medium text-sm ${
-                  activeLogTab === 'rr'
+                  activeLogTab === 'eaco'
                     ? 'border-[#319694] text-[#319694]'
                     : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'
                 }`}
@@ -485,10 +485,10 @@ const ResultsTab = ({ onBackToAnimation, onNewSimulation, rrResults, epsoResults
                 exit={{ opacity: 0 }}
                 transition={{ duration: 0.2 }}
               >
-                {activeLogTab === 'rr' ? (
+                {activeLogTab === 'eaco' ? (
                   <SchedulingLogTable 
                     logs={filteredLogs(resultsRR?.schedulingLog)} 
-                    algorithm="rr" 
+                    algorithm="eaco" 
                   />
                 ) : (
                   <SchedulingLogTable 

--- a/thesis-frontend/src/components/WorkloadTab/WorkloadTab.jsx
+++ b/thesis-frontend/src/components/WorkloadTab/WorkloadTab.jsx
@@ -85,6 +85,9 @@ const WorkloadTab = ({
               onFileUpload={onFileUpload}
               workloadFile={workloadFile}
               csvRowCount={csvRowCount}
+              onPresetSelect={onPresetSelect}
+              selectedPreset={selectedPreset}
+              presetOptions={presetOptions}
             />
           </div>
         ) : (

--- a/thesis-frontend/src/pages/HomePage/HeroSection.jsx
+++ b/thesis-frontend/src/pages/HomePage/HeroSection.jsx
@@ -118,18 +118,18 @@ const HeroSection = ({ onStartSimulation }) => {
   
   const eacoMetrics = [
     { icon: <Cpu />, value: "72-82%", label: "Resource Utilization" },
-    { icon: <Clock />, value: "85-135ms", label: "Response Time" },
+    { icon: <Clock />, value: "85-135", label: "Response Time (secs)" },
     { icon: <Zap />, value: "78-88%", label: "Energy Efficiency" },
     { icon: <Scale />, value: "0.15-0.25", label: "Load Imbalance Factor" },
-    { icon: <Layers />, value: "220-280ms", label: "Makespan" }
+    { icon: <Layers />, value: "220-280", label: "Makespan (secs)" }
   ];
 
   const epsoMetrics = [
     { icon: <Cpu />, value: "80-90%", label: "Resource Utilization" },
-    { icon: <Clock />, value: "75-125ms", label: "Response Time" },
+    { icon: <Clock />, value: "75-125", label: "Response Time (secs)" },
     { icon: <Zap />, value: "85-93%", label: "Energy Efficiency" },
     { icon: <Scale />, value: "0.10-0.20", label: "Load Imbalance Factor" },
-    { icon: <Layers />, value: "200-260ms", label: "Makespan" }
+    { icon: <Layers />, value: "200-260", label: "Makespan (secs)" }
   ];
 
   useEffect(() => {

--- a/thesis-frontend/src/pages/HomePage/HomePage.jsx
+++ b/thesis-frontend/src/pages/HomePage/HomePage.jsx
@@ -51,7 +51,7 @@ const HomePage = () => {
       title: "1. Configure Your Data Center",
       content: [
         "Specify host and VM configurations including processing capabilities, memory, bandwidth, and storage.",
-        "Choose the load balancing algorithm to evaluate (Enhanced ACO, Enhanced PSO, or compare both)."
+        "Choose the load balancing algorithm to evaluate (EACO, EPSO, or compare both)."
       ],
       list: [
         "Number of Hosts",
@@ -116,15 +116,15 @@ const HomePage = () => {
     {
       title: "Algorithms",
       links: [
-        { text: "Enhanced ACO", href: "#", icon: <Cpu size={16} />, onClick: () => openModal('aco') },
-        { text: "Enhanced PSO", href: "#", icon: <Cpu size={16} />, onClick: () => openModal('pso') },
+        { text: "EACO Algorithm", href: "#", icon: <Cpu size={16} />, onClick: () => openModal('aco') },
+        { text: "EPSO Algorithm", href: "#", icon: <Cpu size={16} />, onClick: () => openModal('pso') },
         { text: "Comparison", href: "#", icon: <GitCompare size={16} />, onClick: () => openModal('comparison') }
       ]
     },
     {
       title: "Contact",
       links: [
-        { text: "csa7-2025@gmail.com", href: "gmail.com", icon: <Mail size={16} /> },
+        { text: "csa7-2025@gmail.com", href: "mailto:csa7-2025@gmail.com", icon: <Mail size={16} /> },
       ]
     }
   ];

--- a/thesis-frontend/src/pages/SimulationPage.jsx
+++ b/thesis-frontend/src/pages/SimulationPage.jsx
@@ -320,14 +320,17 @@ const SimulationPage = ({ onBack }) => {
       
       try {
         const eacoResponse = await runAlgorithm("EACO", configData, enableMatlabPlots);
+        console.log('📊 EACO Response from backend:', eacoResponse);
         setProgress(70);
         const epsoResponse = await runAlgorithm("EPSO", configData, enableMatlabPlots);
+        console.log('📊 EPSO Response from backend:', epsoResponse);
         
         const combinedResults = {
           eaco: eacoResponse,
           epso: epsoResponse
         };
         
+        console.log('📊 Combined Results to be saved:', combinedResults);
         setSimulationResults(combinedResults);
         saveToHistory(combinedResults);
         
@@ -496,10 +499,14 @@ const SimulationPage = ({ onBack }) => {
                   : cloudletConfig.numCloudlets
               }}
               workloadFile={workloadFile}
-              rrResults={simulationResults?.eaco}
+              eacoResults={simulationResults?.eaco}
               epsoResults={simulationResults?.epso}
               onBack={() => setSimulationState('config')}
-              onViewResults={() => setSimulationState('results')}
+              onViewResults={() => {
+                console.log('📋 Transitioning to Results Tab');
+                console.log('📋 Current simulationResults:', simulationResults);
+                setSimulationState('results');
+              }}
             />
           </motion.div>
         );
@@ -514,7 +521,7 @@ const SimulationPage = ({ onBack }) => {
           >
             <ResultsTab 
               results={simulationResults}
-              rrResults={simulationResults?.eaco}
+              eacoResults={simulationResults?.eaco}
               epsoResults={simulationResults?.epso}
               plotData={{
                 eaco: simulationResults?.eaco?.plotData,


### PR DESCRIPTION
- Fixed prop name mismatch: changed rrResults to eacoResults in ResultsTab
- Added missing props (onPresetSelect, selectedPreset, presetOptions) to WorkloadUploadCard
- Updated frontend to use backend's loadBalance field instead of non-existent imbalanceDegree
- Changed AnimationTab to display 'Degree of Imbalance' metric (0-100% scale)
- Updated MetricsPanel to show correct labels and descriptions
- Normalized data handling to properly convert backend loadBalance values