### PR TITLE
Fix cache simulation type logic and statistical winner display

### DIFF
--- a/thesis-frontend/src/components/ResultsTab/PairedTTestDisplay.jsx
+++ b/thesis-frontend/src/components/ResultsTab/PairedTTestDisplay.jsx
@@ -41,7 +41,16 @@ const PairedTTestDisplay = ({ tTestResults, comparisonResults, isLoading = false
   }
 
   const { metricTests, overallWinner, significantDifferences, sampleSize, alpha } = tTestResults;
-  // Derive significant count to ensure UI consistency even if backend count is stale
+  
+  const eacoWins = Object.values(metricTests || {}).filter(
+    (t) => t && t.significant && t.betterAlgorithm === 'EACO'
+  ).length;
+  const epsoWins = Object.values(metricTests || {}).filter(
+    (t) => t && t.significant && t.betterAlgorithm === 'EPSO'
+  ).length;
+  const winnerCount = overallWinner === 'EACO' ? eacoWins : 
+                     overallWinner === 'EPSO' ? epsoWins : 0;
+  
   const derivedSignificant = Object.values(metricTests || {}).filter((t) => t && t.significant).length;
   const significantCount = typeof significantDifferences === 'number' ? significantDifferences : derivedSignificant;
   
@@ -194,9 +203,15 @@ const PairedTTestDisplay = ({ tTestResults, comparisonResults, isLoading = false
           </div>
           <div className="text-right">
             <p className="text-3xl font-bold text-[#319694]">
-              {significantCount}/{Object.keys(metricTests || {}).length}
+              {overallWinner === 'No clear winner' ? (
+                `${significantCount}/${Object.keys(metricTests || {}).length}`
+              ) : (
+                `${winnerCount}/${Object.keys(metricTests || {}).length}`
+              )}
             </p>
-            <p className="text-sm text-gray-600">Significant Metrics</p>
+            <p className="text-sm text-gray-600">
+              {overallWinner === 'No clear winner' ? 'Significant Metrics' : 'Metrics Won'}
+            </p>
           </div>
         </div>
       </div>

--- a/thesis-frontend/src/hooks/useSimulationRunner.js
+++ b/thesis-frontend/src/hooks/useSimulationRunner.js
@@ -170,12 +170,20 @@ export const useSimulationRunner = () => {
       return false;
     }
 
-    // Check cache first if enabled
+
     if (useCache && isCacheAvailable()) {
-      const simulationType = workloadFile ? 
-        (iterationConfig.iterations > 1 ? 'iterations-with-file' : 'with-file') :
-        (iterationConfig.iterations > 1 ? 'iterations' : 'raw');
+      const useComparison = iterationConfig.iterations >= 30;
+      let simulationType;
       
+      if (useComparison) {
+        simulationType = workloadFile ? 'compare-with-file' : 'compare';
+      } else if (workloadFile) {
+        simulationType = iterationConfig.iterations > 1 ? 'iterations-with-file' : 'with-file';
+      } else {
+        simulationType = iterationConfig.iterations > 1 ? 'iterations' : 'raw';
+      }
+      
+      console.log(`[Cache] Looking for cached result with simulationType: ${simulationType}, iterations: ${iterationConfig.iterations}, workloadFile: ${!!workloadFile}`);
       const cachedResult = getCachedResult(config, simulationType);
       if (cachedResult) {
         showNotification('Using cached results (instant!)', 'success');
@@ -306,6 +314,7 @@ export const useSimulationRunner = () => {
           // cache the results for future use
           if (isCacheAvailable()) {
             const simulationType = workloadFile ? 'compare-with-file' : 'compare';
+            console.log(`[Cache] Storing comparison results with simulationType: ${simulationType}, iterations: ${iterationConfig.iterations}`);
             cacheResult(config, combinedResults, simulationType);
           }
         } else {
@@ -411,11 +420,19 @@ export const useSimulationRunner = () => {
             setSimulationResults(combinedResults);
             historyService.saveToHistory(combinedResults, dataCenterConfig, cloudletConfig, workloadFile);
             
-            // Cache the results for future use
             if (isCacheAvailable()) {
-              const simulationType = workloadFile ? 
-                (iterationConfig.iterations > 1 ? 'iterations-with-file' : 'with-file') :
-                (iterationConfig.iterations > 1 ? 'iterations' : 'raw');
+              const useComparisonForCaching = iterationConfig.iterations >= 30;
+              let simulationType;
+              
+              if (useComparisonForCaching) {
+                simulationType = workloadFile ? 'compare-with-file' : 'compare';
+              } else if (workloadFile) {
+                simulationType = iterationConfig.iterations > 1 ? 'iterations-with-file' : 'with-file';
+              } else {
+                simulationType = iterationConfig.iterations > 1 ? 'iterations' : 'raw';
+              }
+              
+              console.log(`[Cache] Storing non-comparison results with simulationType: ${simulationType}, iterations: ${iterationConfig.iterations}`);
               cacheResult(config, combinedResults, simulationType);
             }
           }

--- a/thesis-frontend/src/utils/resultCache.js
+++ b/thesis-frontend/src/utils/resultCache.js
@@ -60,6 +60,7 @@ export const generateCacheKey = (config, simulationType = 'raw') => {
 export const getCachedResult = (config, simulationType = 'raw') => {
   try {
     const cacheKey = generateCacheKey(config, simulationType);
+    console.log(`[Cache] getCachedResult called with simulationType: ${simulationType}, iterations: ${config.iterationConfig?.iterations}, key: ${cacheKey}`);
     const cached = localStorage.getItem(cacheKey);
     
     if (!cached) {
@@ -99,6 +100,7 @@ export const getCachedResult = (config, simulationType = 'raw') => {
 export const cacheResult = (config, results, simulationType = 'raw') => {
   try {
     const cacheKey = generateCacheKey(config, simulationType);
+    console.log(`[Cache] cacheResult called with simulationType: ${simulationType}, iterations: ${config.iterationConfig?.iterations}, key: ${cacheKey}`);
     
        //dont cache plot data 
     const resultsToCache = {


### PR DESCRIPTION
Cache fixes:
- Fix cache lookup to match actual execution paths (comparison mode for 30+ iterations)
- Add debug logging to track cache behavior
- Ensure cache storage and lookup use identical simulation type logic

Statistical display fix:
- Fix misleading 5/5 display to show actual algorithm wins (4/5 for EPSO)
- Calculate individual algorithm win counts instead of total significant metrics
- Change label from 'Significant Metrics' to 'Metrics Won' for winner display